### PR TITLE
Relaxed the restrictions for dotenv. 

### DIFF
--- a/capistrano-deploy.gemspec
+++ b/capistrano-deploy.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency('capistrano', '~> 2.9')
   s.add_dependency('hipchat', '1.1.0')
-  s.add_dependency('dotenv', '~> 0.8.0')
+  s.add_dependency('dotenv', '> 0.8.0')
 end


### PR DESCRIPTION
We previously had it locked in at v0.8.0 because our env

files were breaking after v0.9.0, but I have tested it against our production environment
files and it is working well.

We made modifications to the most recent version of dotenv to support overloading environment
variables so that we could achieve zero-downtime deployments in situations where environment
variable values had changed. 
- [ ] Change log
- [ ] Demo page
- [ ] Product owner signoff
