### PR TITLE
sentinel breaks otherwise

### DIFF
--- a/capistrano-deploy.gemspec
+++ b/capistrano-deploy.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |s|
   s.add_dependency('capistrano', '~> 2.9')
   s.add_dependency('hipchat', '1.1.0')
   s.add_dependency('dotenv', '> 0.8.0')
+  s.add_dependency('net-ssh', '~> 2.0')
 end


### PR DESCRIPTION
ruby 1.9.3 doesn't support net-ssh 3.0.0 …or greater
I need this to deploy the branch-specific deploy code on the sentinel servers which are running ruby 1.9.3
