### PR TITLE
Fixed the environment branch push for aws

### DIFF
--- a/lib/capistrano-deploy/aws.rb
+++ b/lib/capistrano-deploy/aws.rb
@@ -5,29 +5,31 @@ module CapistranoDeploy
 
         set(:environment_file) { ".env" }
         set(:temp_folder) { "./tmp/env_config" }
-        
+        set(:environment_branch) { "master" }
+
         namespace :aws do
           desc "Push ENV file from local to AWS"
           task :setup do
             require 'capistrano-deploy/utilities'
             utilities = ::CapistranoDeploy::Utilities.new(
-              environment_file: environment_file, 
-              temp_folder: temp_folder, 
-              app_name: app_name, 
+              environment_file: environment_file,
+              temp_folder: temp_folder,
+              app_name: app_name,
               environment_repository: environment_repository,
-              current_stage: current_stage
+              current_stage: current_stage,
+              environment_branch: environment_branch
             )
-            
+
             utilities.fetch_config
 
             utilities.local_files.each do |file|
               msg = "Do you wish to overwrite the #{current_stage} #{environment_file} file with your local version? WARNING: You should have pulled in the latest version locally via the environment:servers:local task (y/n)? "
-              if /^y/i =~ Capistrano::CLI.ui.ask(msg)              
+              if /^y/i =~ Capistrano::CLI.ui.ask(msg)
                 upload file, File.join(deploy_to, environment_file)
               else
                 puts "Config not changed"
-              end 
-            end     
+              end
+            end
           end
         end
       end

--- a/lib/capistrano-deploy/environment.rb
+++ b/lib/capistrano-deploy/environment.rb
@@ -37,7 +37,8 @@ module CapistranoDeploy
                 environment_file: environment_file,
                 temp_folder: temp_folder,
                 app_name: app_name,
-                environment_repository: environment_repository
+                environment_repository: environment_repository,
+                environment_branch: environment_branch
               )
 
               utilities.fetch_config

--- a/lib/capistrano-deploy/utilities.rb
+++ b/lib/capistrano-deploy/utilities.rb
@@ -1,27 +1,29 @@
 module CapistranoDeploy
   class Utilities
-    attr_accessor :environment_file, :temp_folder, :app_name, :environment_repository, :local_files, :current_stage
-    
+    attr_accessor :environment_file, :temp_folder, :app_name, :environment_repository,
+      :local_files, :current_stage, :environment_branch
+
     def initialize(args = {})
       self.environment_file = args.fetch(:environment_file)
+      self.environment_branch = args.fetch(:environment_branch)
       self.temp_folder = args.fetch(:temp_folder)
       self.app_name = args.fetch(:app_name)
       self.environment_repository = args.fetch(:environment_repository)
       self.local_files = args.fetch(:local_files, [])
       self.current_stage = args.fetch(:current_stage, nil)
     end
-    
+
     def fetch_config
-      if /^y/i =~ Capistrano::CLI.ui.ask("Do you wish to overwrite your local #{environment_file} file (y/n)? ")
-        system "rm -rf #{temp_folder} && git clone -n #{environment_repository} --depth 1 #{temp_folder}"
+      if /^y/i =~ Capistrano::CLI.ui.ask("Do you wish to overwrite your local #{environment_file} file from branch #{environment_branch} (y/n)? ")
+        system "rm -rf #{temp_folder} && git clone -b #{environment_branch} -n #{environment_repository} --depth 1 #{temp_folder}"
         system "cd #{temp_folder} && git checkout HEAD #{app_name}/.env.*"
         system "cp #{temp_folder}/#{app_name}/.env.* ."
         system "cp .env.development .env"
-        
+
         self.local_files = Dir.glob("#{temp_folder}/#{app_name}/.env.#{current_stage}", File::FNM_DOTMATCH)
       else
         puts "Environmental files not updated."
       end
-    end 
+    end
   end
 end


### PR DESCRIPTION
:elephant: 
* deploy environment branches setted in the capfile by
```
set :environment_branch, 'your_env_branch'
```
was not working for aws deploys because the aws uses a different task
to handle the env pull and push to the server, make the changes to the
aws env task to take the set environment branch or default it to master.