### PR TITLE
Needed to update dot-env gem

### DIFF
--- a/capistrano-deploy.gemspec
+++ b/capistrano-deploy.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency('capistrano', '~> 2.9')
   s.add_dependency('hipchat', '1.1.0')
-  s.add_dependency('dotenv', '~> 1.0.2')
+  s.add_dependency('dotenv', '~> 2.1.0')
   s.add_dependency('net-ssh', '~> 2.0')
 end


### PR DESCRIPTION
:elephant: 

## Fixing ENV branch deployments  

* Currently deploying branches for env's is broken for driversed and forms2 because you cannot
  update to the latest version of capistrano-amadeploy and it is out of date by at least a three
  PR's at the moment.
  * When you try and update you get a message like:
    * Bundler could not find compatible versions for gem "dotenv":
      In Gemfile:
        capistrano-deploy was resolved to 0.3.2, which depends on
          dotenv (~> 1.0.2)

          dotenv-rails was resolved to 2.1.0, which depends on
            dotenv (= 2.1.0)
  * Updating fixes the issue and allows you deploy branches of env's again.