### PR TITLE
Make our deployment messages match Hipchat gem

### DIFF
--- a/lib/capistrano-deploy/hipchat.rb
+++ b/lib/capistrano-deploy/hipchat.rb
@@ -5,23 +5,67 @@ module CapistranoDeploy
         namespace :hipchat do
           require 'hipchat'
 
-          set(:deployer) { %x(git config user.name).chomp }
+          set(:deployer) { human }
+
           desc 'Set notification in hipchat for deployment start'
           task :start_msg do
             client = HipChat::Client.new(hipchat_token)
-            deploy_text = "#{deployer} is starting deploy of '#{app_name.upcase}' from branch '#{branch.upcase}' to #{current_stage.upcase}"
-
+            deploy_text = "#{human} is deploying #{deployment_name} to #{environment_string}."
             client[hipchat_room].send('Deploy', deploy_text, color: 'yellow')
           end
 
           desc 'Set notification in hipchat for deployment end'
           task :end_msg do
             client = HipChat::Client.new(hipchat_token)
-            deploy_text = "#{deployer} completed the deploy of '#{app_name.upcase}' from branch '#{branch.upcase}' to #{current_stage.upcase}"
+            deploy_text = "#{human} finished deploying #{deployment_name} to #{environment_string}."
 
             client[hipchat_room].send('Deploy', deploy_text, color: 'green')
           end
+
+          def human
+            user = ENV['HIPCHAT_USER'] || fetch(:hipchat_human, %x(git config user.name).chomp)
+            user = user || if (u = %x{git config user.name}.strip) != ''
+                             u
+                           elsif (u = ENV['USER']) != ''
+                             u
+                           else
+                             'Someone'
+                           end
+            user
+          end
+
+          def deployment_name
+             if fetch(:branch, nil)
+               branch = fetch(:branch)
+               name = "#{application_name}/#{branch}"
+               name
+             else
+               application_name
+             end
+          end
+
+          def application_name
+            alt_application_name.nil? ? fetch(:application) : alt_application_name
+          end
+
+          def alt_application_name
+            fetch(:hipchat_app_name, nil) || fetch(:app_name, nil)
+          end
+
+          def environment_string
+            if fetch(:current_stage, nil)
+              "#{fetch(:current_stage)} (#{environment_name})"
+            else
+              environment_name
+            end
+          end
+
+          def environment_name
+            fetch(:hipchat_env, fetch(:rack_env, fetch(:rails_env, fetch(:current_stage))))
+          end
+
         end
+
       end
     end
   end


### PR DESCRIPTION
https://github.com/hipchat/hipchat-rb/blob/master/lib/hipchat/capistrano/tasks/hipchat.rake#L5

* Copies code directly from Hipchat gem
* Changing our message so that is the same as the message that Hipchat
generates (so we'll have less to change when we drop capistrano-deploy)
* After this change we'll be able to update our Hipchat rooms by
searching for a single message using
https://rubygems.org/gems/lita-server_status

Start message:
```
Firstname Lastname is deploying awesome/master to staging (production).
```
End Message:
```
Firstname Lastname finished deploying awesome/master to staging (production).
```